### PR TITLE
Workaround test cleanup issues for Windows

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,16 +1,7 @@
 getPkgDir <- function(){
-  temp_dir <- file.path(tempdir(), "packages")
+  temp_dir <- tempfile()
   dir.create(temp_dir)
   return(temp_dir)
-}
-
-cleanup <- function(temp_dir){
-  if(dir.exists(temp_dir)){
-    unlink(
-      file.path(temp_dir),
-      recursive=T
-    )
-  }
 }
 
 initPkg <- function(temp_dir, package_name, more_args=NULL){

--- a/tests/testthat/test-build.R
+++ b/tests/testthat/test-build.R
@@ -1,8 +1,9 @@
-tdir <- getPkgDir()
-pkgn <- "testPkg"
 
 testthat::test_that("checking package build", {
 
+  tdir <- getPkgDir()
+  pkgn <- "testPkg"
+  
   path <- file.path(tdir, pkgn)
   initPkg(tdir, pkgn, list(renv_init = FALSE))
 
@@ -134,5 +135,3 @@ testthat::test_that("checking package render",{
   ## check that working env contains render generated var names
 
 })
-
-cleanup(tdir)

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -91,5 +91,3 @@ test_that("check stop on existing init directory", {
   unlink(path, recursive = TRUE)
 
 })
-
-cleanup(tdir)

--- a/tests/testthat/test-versioning.R
+++ b/tests/testthat/test-versioning.R
@@ -52,7 +52,6 @@ testthat::test_that("checking package data hashes report", {
   )
   
   unlink(path, recursive = TRUE)
-  cleanup(tdir)
   
 })
 
@@ -176,6 +175,5 @@ testthat::test_that("checking package data history with git", {
   )
 
   unlink(path, recursive = TRUE)
-  cleanup(tdir)
   
 })


### PR DESCRIPTION
This addresses issue #38 . Windows is failing silently to unlink folders during tests. This PR simply creates a new folder at a random location in the temp directory instead. It does not attempt to reuse paths, or unlink files in temp that are created during tests. One downside to this approach is that files can accumulate in the temp directory after several tests. 