### PR TITLE
enable force flag in tests for windows unlink

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -8,7 +8,8 @@ cleanup <- function(temp_dir){
   if(dir.exists(temp_dir)){
     unlink(
       file.path(temp_dir),
-      recursive=T
+      recursive=TRUE,
+      force=TRUE
     )
   }
 }


### PR DESCRIPTION
Setting force to true in the unlink call appears to fix #38, while still cleaning up as previous tests did. 

The issue I found was that the `.git/objects` directory was not able to be deleted by normal user permissions after objects were added to it during an active session. Setting `unlink` to `force = TRUE` appears to have worked in resetting the permissions in this case. 

https://stat.ethz.ch/R-manual/R-devel/library/base/html/unlink.html