### PR TITLE
rm auto-increment data versions arg from yml

### DIFF
--- a/inst/templates/datapackager.yml
+++ b/inst/templates/datapackager.yml
@@ -6,7 +6,6 @@ process_directory: processing
 process_on_build:
 render_on_build: yes
 write_to_vignettes: yes
-auto_increment_data_versions: yes
 purge_data_directory: yes
 data_digest_directory: inst/data_digest
 render_env_mode: isolate


### PR DESCRIPTION
Resolves #47.

To avoid potential confusion, could also consider renaming the unrelated function `dpr_recall_data_versions()`, which works with hashes, not incremental versions.