### PR TITLE
remove renv init, now must be called manually by the user

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,4 @@ All branches will fall into these reference sub-directories.
 
 For example:
 
-`feature/renv_integration`
+`feature/dpr_convert`

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ Imports:
     desc,
     digest,
     pkgbuild,
-    renv,
     rmarkdown,
     rprojroot,
     utils,

--- a/R/compatibility.R
+++ b/R/compatibility.R
@@ -150,9 +150,8 @@ dpr1_clean <- function(path){
 dpr_convert <- function(path = "."){
   if( !dpr_is_dpr1(path) )
     stop("Data package at path argument is not detected as DataPackageR package.")
-  # renv should not be initialized, defaulting to the repo's current renv configuration, whatever that may be
   suppressWarnings(
-    dpr_init(path, dpr_yaml_init(process_directory = "data-raw", purge_data_directory = FALSE), renv_init=FALSE)
+    dpr_init(path, dpr_yaml_init(process_directory = "data-raw", purge_data_directory = FALSE))
   )
   dpr1_yaml_convert(path)
   dpr1_data_digest_convert(path)

--- a/R/create.R
+++ b/R/create.R
@@ -139,10 +139,9 @@ dpr_description_init <- function(...){
 #' @param path A path to the data package.
 #' @param yaml A returned list for [dpr_yaml_init()]
 #' @param desc A returned list for [dpr_description_init()]
-#' @param renv_init Logical; whether to initiate renv (default TRUE)
 #' @author jmtaylor
 #' @export
-dpr_create <- function(path = ".", yaml = dpr_yaml_init(), desc = dpr_description_init(), renv_init = TRUE){
+dpr_create <- function(path = ".", yaml = dpr_yaml_init(), desc = dpr_description_init()){
   pkgp <- file.path(path, desc$Package)
 
   if(!dir.exists(path))
@@ -169,15 +168,6 @@ dpr_create <- function(path = ".", yaml = dpr_yaml_init(), desc = dpr_descriptio
           dpr_yaml_init_set(yaml, pkgp)
       }
 
-    ## init renv
-    if(renv_init && !file.exists(file.path(pkgp, "renv.lock")))
-      renv::init(
-        pkgp,
-        settings = list(snapshot.type = "implicit"),
-        load = FALSE,
-        restart = FALSE
-      )
-
     dpr_update_ignores(pkgp)
 
   },
@@ -200,19 +190,16 @@ dpr_create <- function(path = ".", yaml = dpr_yaml_init(), desc = dpr_descriptio
 #' @param desc A returned list from [dpr_description_init()]. The default
 #'   argument sets the package name to the name of the directory containing the
 #'   data package.
-#' @param renv_init Logical; whether to initiate renv (default TRUE)
 #' @export
 dpr_init <- function(
     path = ".",
     yaml = dpr_yaml_init(),
-    desc = dpr_description_init(Package = basename(path)),
-    renv_init = TRUE)
+    desc = dpr_description_init(Package = basename(path)))
 {
   path <- normalizePath(path)
   dpr_create(
     dirname(path),
     yaml = yaml,
-    desc = desc,
-    renv_init = renv_init
+    desc = desc
   )
 }

--- a/man/dpr_create.Rd
+++ b/man/dpr_create.Rd
@@ -4,12 +4,7 @@
 \alias{dpr_create}
 \title{dpr_create}
 \usage{
-dpr_create(
-  path = ".",
-  yaml = dpr_yaml_init(),
-  desc = dpr_description_init(),
-  renv_init = TRUE
-)
+dpr_create(path = ".", yaml = dpr_yaml_init(), desc = dpr_description_init())
 }
 \arguments{
 \item{path}{A path to the data package.}
@@ -17,8 +12,6 @@ dpr_create(
 \item{yaml}{A returned list for \code{\link[=dpr_yaml_init]{dpr_yaml_init()}}}
 
 \item{desc}{A returned list for \code{\link[=dpr_description_init]{dpr_description_init()}}}
-
-\item{renv_init}{Logical; whether to initiate renv (default TRUE)}
 }
 \description{
 Initialize a data package by creating a structured directory skeleton for a

--- a/man/dpr_init.Rd
+++ b/man/dpr_init.Rd
@@ -7,8 +7,7 @@
 dpr_init(
   path = ".",
   yaml = dpr_yaml_init(),
-  desc = dpr_description_init(Package = basename(path)),
-  renv_init = TRUE
+  desc = dpr_description_init(Package = basename(path))
 )
 }
 \arguments{
@@ -20,8 +19,6 @@ the current working directory is used.}
 \item{desc}{A returned list from \code{\link[=dpr_description_init]{dpr_description_init()}}. The default
 argument sets the package name to the name of the directory containing the
 data package.}
-
-\item{renv_init}{Logical; whether to initiate renv (default TRUE)}
 }
 \description{
 A wrapper for dpr_create that uses the parent directory as the location to

--- a/tests/testthat/test-build.R
+++ b/tests/testthat/test-build.R
@@ -7,7 +7,7 @@ pkgn <- "testPkg"
 testthat::test_that("checking package build", {
 
   path <- file.path(tdir, pkgn)
-  createPkg(tdir, pkgn, list(renv_init = FALSE))
+  createPkg(tdir, pkgn)
 
   rda_to_restore <- file.path(path, 'data', 'restore_me.rda')
   file.create(rda_to_restore)

--- a/tests/testthat/test-compatibility.R
+++ b/tests/testthat/test-compatibility.R
@@ -22,7 +22,7 @@ testthat::test_that("checking DataPackageR compatibility functions", {
 
   pkgn <- "testPkg"
   path2 <- file.path(tdir, pkgn)
-  createPkg(tdir, pkgn, list(renv_init = FALSE))
+  createPkg(tdir, pkgn)
 
   expect_error(
     dpr_convert(path2),

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -88,21 +88,6 @@ test_that("check datapackager.yml and ignores", {
   unlink(file.path(tdir, pkgn), recursive = TRUE)
 })
 
-test_that("check renv", {
-
-  pkgn <- "testPkg"
-  path <- file.path(tdir, pkgn)
-
-  createPkg(tdir, pkgn, list(renv_init=TRUE))
-  expect_true(dir.exists(file.path(path, "renv")))
-  unlink(path, recursive = TRUE)
-
-  createPkg(tdir, pkgn, list(renv_init=FALSE))
-  expect_true(!dir.exists(file.path(path, "renv")))
-  unlink(path, recursive = TRUE)
-
-})
-
 test_that("init populates exisiting directory", {
 
   pkgn <- "initExist"
@@ -143,7 +128,7 @@ test_that("no dpr_(description_)_init warning about default package name", {
   twd <- tempfile()
   dir.create(twd)
   setwd(twd)
-  expect_no_warning(dpr_init(renv_init = FALSE))
+  expect_no_warning(dpr_init())
 })
 
 cleanup(tdir)

--- a/tests/testthat/test-object-documentation.R
+++ b/tests/testthat/test-object-documentation.R
@@ -10,7 +10,7 @@ test_that("check that R object documentation is written as expected", {
   tdir <- getPkgDir()
   pkgn <- "testPkg"
   path <- file.path(tdir, pkgn)
-  createPkg(tdir, pkgn, list(renv_init = FALSE))
+  createPkg(tdir, pkgn)
   dpr_build(path, process_on_build = "01.R", objects = "objYml1")
   # check that .R file exists
   expect_true(file.exists(file.path(path, "R", "objYml1.R")))
@@ -70,7 +70,7 @@ test_that("check that delete_unused_doc_files accurately deletes unused R doc fi
   tdir <- getPkgDir()
   pkgn <- "testPkg"
   path <- file.path(tdir, pkgn)
-  createPkg(tdir, pkgn, list(renv_init = FALSE))
+  createPkg(tdir, pkgn)
   writeLines(
     c(
       "library(DPR2)",


### PR DESCRIPTION
This addresses #84 . `renv` has been removed as a dependency and is no longer initialized when a DPR2 package is created. Figure documentation will instruct users to initialize `renv` manually. 