### PR TITLE
debug and repair apt and CRAN dependencies for R 4.0.4 CI runner

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,6 +53,8 @@ jobs:
           sudo apt install -y libx11-dev libcurl4-openssl-dev libssl-dev libgit2-dev libssh2-1-dev libicu-dev libxml2-dev
           R -q -e 'utils::install.packages(c("remotes", "rcmdcheck"))'
           R -q -e 'remotes::install_version("gh", "1.4.1")'
+          R -q -e 'utils::install.packages(c("rmarkdown", "roxygen2", "yaml", "DataPackageR", "git2r", "testthat", "lubridate"))'
+        # previous line can be unhardcoded more easily (cf. VISCtemplates) once DPR2 is a public repo
 
       - uses: r-lib/actions/setup-tinytex@v2
 


### PR DESCRIPTION
Fixes pak dependency resolution error at https://github.com/FredHutch/DPR2/actions/runs/15598066520/job/43932707984?pr=98 due to most recent version of `gh` package no longer supporting R < 4.1