### PR TITLE
change `write_docs` to `write_data_docs`

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -205,7 +205,7 @@ dpr_render <- function(path=".", ...){
       )
     )
 
-  if(yml$write_docs){
+  if(yml$write_data_docs){
     if(!data_is_empty(path=path)){
       generate_all_docs(path=path)
       suppressPackageStartupMessages(

--- a/inst/templates/datapackager.yml
+++ b/inst/templates/datapackager.yml
@@ -4,7 +4,7 @@ process_directory: processing
 render_on_build: yes
 render_env_mode: isolate
 write_to_vignettes: yes
-write_docs: yes
+write_data_docs: yes
 to_build_directory: inst/to_build
 build_tarball: no
 install_on_build: no

--- a/tests/testthat/test-object-documentation.R
+++ b/tests/testthat/test-object-documentation.R
@@ -129,7 +129,7 @@ test_that("check that delete_unused_doc_files accurately deletes unused R doc fi
 
   dpr_add_scripts("df_gen.R", path)
 
-  dpr_build(path, write_docs = FALSE)
+  dpr_build(path, write_data_docs = FALSE)
   expect_true(
     length(list.files(file.path(path, "R"))) == 0
   )


### PR DESCRIPTION
This PR changes the yaml field `write_docs` to `write_data_docs` in effort to bring more clarity to what this field will control when building the data package. 