### PR TITLE
install diffdf for R 4.0.4 Suggests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,7 +53,7 @@ jobs:
           sudo apt install -y libx11-dev libcurl4-openssl-dev libssl-dev libgit2-dev libssh2-1-dev libicu-dev libxml2-dev
           R -q -e 'utils::install.packages(c("remotes", "rcmdcheck"))'
           R -q -e 'remotes::install_version("gh", "1.4.1")'
-          R -q -e 'utils::install.packages(c("rmarkdown", "roxygen2", "yaml", "DataPackageR", "git2r", "testthat", "lubridate"))'
+          R -q -e 'utils::install.packages(c("rmarkdown", "roxygen2", "yaml", "DataPackageR", "diffdf", "git2r", "testthat", "lubridate"))'
         # previous line can be unhardcoded more easily (cf. VISCtemplates) once DPR2 is a public repo
 
       - uses: r-lib/actions/setup-tinytex@v2


### PR DESCRIPTION
This PR adds the new `diffdf` Suggests dependency to the R 4.0.4 CI runner to fix the build error [here](https://github.com/FredHutch/DPR2/actions/runs/16148408834/job/45573208702).

Before we merge this, it's worth asking whether we want to have this additional dependency just to put this line in the vignette:

```
We can inspect the changes between the two versions using `diffdf::diffdf`.

diffdf::diffdf(
  dataversions[[1]][[1]],
  dataversions[[2]][[1]]
)
```

Comparing data.frames isn't DPR2-specific, and could be done in many ways, most of which don't involve `diffdf`.