### PR TITLE
use frozen CRAN and pak-resolved dependencies for R 4.0.4. CI runner

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,25 +41,24 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v2
+      - name: Setup recent R
+        uses: r-lib/actions/setup-r@v2
+        if: ${{ matrix.config.r != '4.0.4' }}
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Install statsrv packages
+      - name: Setup R 4.0.4
+        uses: r-lib/actions/setup-r@v2
         if: ${{ matrix.config.r == '4.0.4' }}
-        run: |
-          sudo apt install -y libx11-dev libcurl4-openssl-dev libssl-dev libgit2-dev libssh2-1-dev libicu-dev libxml2-dev
-          R -q -e 'utils::install.packages(c("remotes", "rcmdcheck"))'
-          R -q -e 'remotes::install_version("gh", "1.4.1")'
-          R -q -e 'utils::install.packages(c("rmarkdown", "roxygen2", "yaml", "DataPackageR", "diffdf", "git2r", "testthat", "lubridate"))'
-        # previous line can be unhardcoded more easily (cf. VISCtemplates) once DPR2 is a public repo
+        with:
+          r-version: ${{ matrix.config.r }}
+          cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2025-05-25'
 
       - uses: r-lib/actions/setup-tinytex@v2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        if: ${{ matrix.config.r != '4.0.4' }}
         with:
           extra-packages: any::rcmdcheck
           needs: check


### PR DESCRIPTION
For R 4.0.4 runner, use CRAN repository frozen to the day prior to package `gh` dropping support for R 4.0.4.  Obviates future updates & hardcoding when other packages drop support for R 4.0.4, and allows using pak to keep track of apt dependencies.

e.g., avoids things like this (DPR2 recursive dependency purrr now requires R >= 4.1):
https://github.com/FredHutch/DPR2/actions/runs/16229855511/job/45832699538