### PR TITLE
use binary gzip compression for RDAs despite user/rstudio options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R:
 Description: Build automation and dataset tracking for R data packages. Based on DataPackageR.
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Depends:
     R (>= 3.5)
 Imports:

--- a/R/utility.R
+++ b/R/utility.R
@@ -194,23 +194,34 @@ dpr_description_set <- function(path=".", ...){
 #' A convenience function for writing data objects to the package data
 #' directory.
 #'
-#' @description `dpr_save` is vecotorized so users may pass a character vector
+#' @description `dpr_save` is vectorized so users may pass a character vector
 #'   of object names found in the calling environment to save to the `data`
 #'   directory when the package is built. All objects are saved as single object
 #'   `Rda` files by the object names that are passed.
 #' @title dpr_save
 #' @param objects Character vector of object names to be saved from the
 #'   environment specified in `envir`.
-#' @param path The path to the data package. Defaults to `dpr_path()`.
+#' @param path The path to the data package. Defaults to [dpr_path()].
 #' @param envir The environment to search for objects to save. Defaults to
 #'   calling environment.
+#' @param ascii Argument passed to [save()]. Modifying this default is for
+#'   advanced use only.
+#' @param compress Argument passed to [save()]. Modifying this default is for
+#'   advanced use only.
 #' @returns The original `objects` argument, invisibly.
 #' @export
-dpr_save <- function(objects, path = dpr_path(), envir = parent.frame()){
+dpr_save <- function(objects, path = dpr_path(), envir = parent.frame(),
+                     ascii = FALSE, compress = !ascii){
   if(!is.character(objects))
     stop("Only character vectors allowed.")
   for(obj in objects){
-    save(list=obj, file = file.path(path, "data", paste0(obj, ".rda")), envir=envir)
+    save(
+      list = obj,
+      file = file.path(path, "data", paste0(obj, ".rda")),
+      envir = envir,
+      ascii = ascii,
+      compress = compress
+    )
   }
   invisible(objects)
 }

--- a/man/dpr_save.Rd
+++ b/man/dpr_save.Rd
@@ -4,22 +4,34 @@
 \alias{dpr_save}
 \title{dpr_save}
 \usage{
-dpr_save(objects, path = dpr_path(), envir = parent.frame())
+dpr_save(
+  objects,
+  path = dpr_path(),
+  envir = parent.frame(),
+  ascii = FALSE,
+  compress = !ascii
+)
 }
 \arguments{
 \item{objects}{Character vector of object names to be saved from the
 environment specified in \code{envir}.}
 
-\item{path}{The path to the data package. Defaults to \code{dpr_path()}.}
+\item{path}{The path to the data package. Defaults to \code{\link[=dpr_path]{dpr_path()}}.}
 
 \item{envir}{The environment to search for objects to save. Defaults to
 calling environment.}
+
+\item{ascii}{Argument passed to \code{\link[=save]{save()}}. Modifying this default is for
+advanced use only.}
+
+\item{compress}{Argument passed to \code{\link[=save]{save()}}. Modifying this default is for
+advanced use only.}
 }
 \value{
 The original \code{objects} argument, invisibly.
 }
 \description{
-\code{dpr_save} is vecotorized so users may pass a character vector
+\code{dpr_save} is vectorized so users may pass a character vector
 of object names found in the calling environment to save to the \code{data}
 directory when the package is built. All objects are saved as single object
 \code{Rda} files by the object names that are passed.

--- a/tests/testthat/test-utility.R
+++ b/tests/testthat/test-utility.R
@@ -1,0 +1,26 @@
+testthat::test_that("dpr_save() always saves binary/gzip RDAs", {
+  old_option <- getOption("save.defaults")
+  on.exit(options(save.defaults = old_option))
+
+  check_fn <- function(...){
+    df <- data.frame(1:10)
+    tf <- tempfile()
+    on.exit(unlink(tf, recursive = TRUE))
+    td <- file.path(tf, 'data')
+    dir.create(td, recursive = TRUE)
+    DPR2::dpr_save('df', tf, ...)
+    digest::digest(file = file.path(td, 'df.rda'))
+  }
+
+  # mimic serialization overrides forced by Rstudio server
+  # https://github.com/rstudio/rstudio/issues/16419
+  options(save.defaults = list(ascii = FALSE, compress = FALSE))
+  hash_rstudio <- check_fn()
+  # mimic default serialization options in base R save()
+  options(save.defaults = NULL)
+  hash_r <- check_fn()
+  expect_equal(hash_r, hash_rstudio)
+  # can still customize serialization via dpr_save arguments
+  hash_custom <- check_fn(ascii = FALSE, compress = FALSE)
+  expect_false(hash_r == hash_custom)
+})


### PR DESCRIPTION
Closes #118.