### PR TITLE
add pkgdown site w/ action to build to GH pages

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,6 @@
 ^README\.Rmd$
 ^doc$
 ^Meta$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,9 +24,9 @@ jobs:
       contents: write
     steps:
       - name: configure git user for tests
-          run: |
-            git config --global user.name notauser
-            git config --global user.email notauser@notauser.com
+        run: |
+          git config --global user.name notauser
+          git config --global user.email notauser@notauser.com
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -23,6 +23,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: configure git user for tests
+          run: |
+            git config --global user.name notauser
+            git config --global user.email notauser@notauser.com
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ inst/doc
 /Meta/
 vignettes/*.html
 vignettes/*.R
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,3 +33,4 @@ Suggests:
     lubridate,
     testthat
 VignetteBuilder: knitr
+URL: https://fredhutch.github.io/DPR2/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,13 @@
 url: https://fredhutch.github.io/DPR2/
+articles:
+  - title: Articles
+    navbar: ~
+    contents:
+    - introduction_to_dpr2
+    - the_dpr2_workflow
+    - data_documentation
+    - data_versioning
+    - datapackager_compatibility
 template:
   bootstrap: 5
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://fredhutch.github.io/DPR2/
+template:
+  bootstrap: 5
+

--- a/man/DPR2-package.Rd
+++ b/man/DPR2-package.Rd
@@ -8,6 +8,13 @@
 \description{
 Build automation and dataset tracking for R data packages. Based on DataPackageR.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://fredhutch.github.io/DPR2/}
+}
+
+}
 \author{
 \strong{Maintainer}: Jason Taylor \email{jmtaylor@fredhutch.org}
 


### PR DESCRIPTION
Should render to the github.io URL upon merge to `main`.

Can preview locally with `pkgdown::build_site()`