### PR TITLE
Fix/unprocessed vignette

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -39,7 +39,6 @@ process_vignettes <- function(path, processing_dir, vignette_tempdir){
   vignettes_dir <- file.path(path, 'vignettes')
   if (!dir.exists(vignettes_dir)) dir.create(vignettes_dir)
 
-  srcs <- list.files(file.path(path, processing_dir), full.names = TRUE)
   md_files <- list.files(vignettes_tempdir, pattern = '\\.md$', full.names = TRUE, ignore.case = TRUE)
   file.rename(md_files, sub('\\.md$', '.Rmd', md_files))
 
@@ -52,6 +51,8 @@ process_vignettes <- function(path, processing_dir, vignette_tempdir){
   )
 
   vigs <- file.path(vignettes_dir, basename(tempnames))
+
+  srcs <- list.files(file.path(path, processing_dir), full.names = TRUE)
 
   for(vig in vigs[!file.info(vigs)$isdir]){
     lins <- readLines(vig)

--- a/R/build.R
+++ b/R/build.R
@@ -62,8 +62,8 @@ process_vignettes <- function(path, processing_dir, vignettes_tempdir){
       src <- readLines(srcs[ tolower(basename(srcs)) %in% tolower(basename(vig)) ])
 
       yml_idx <- which(grepl("^---$", src))
-      if(length(yml_idx)== 0)  yml_idx <- c(0, 0)
-      rmd_yml <- yaml::read_yaml(text = src[seq(yml_idx[1], yml_idx[2])])
+      if(length(yml_idx) != 2)  yml_idx <- c(0, 0)
+      rmd_yml <- yaml::read_yaml(text = src[yml_idx[1]:yml_idx[2]])
 
       rmd_yml$vignette <-
         sprintf(

--- a/R/build.R
+++ b/R/build.R
@@ -62,7 +62,7 @@ process_vignettes <- function(path, processing_dir, vignette_tempdir){
 
       yml_idx <- which(grepl("^---$", src))
       if(length(yml_idx)== 0)  yml_idx <- c(0, 0)
-      rmd_yml <- yaml::read_yaml(text = src[seq_len(yml_idx[2])])
+      rmd_yml <- yaml::read_yaml(text = src[seq(yml_idx[1], yml_idx[2])])
 
       rmd_yml$vignette <-
         sprintf(

--- a/R/build.R
+++ b/R/build.R
@@ -40,17 +40,20 @@ process_vignettes <- function(path, processing_dir, vignette_tempdir){
   if (!dir.exists(vignettes_dir)) dir.create(vignettes_dir)
 
   srcs <- list.files(file.path(path, processing_dir), full.names = TRUE)
+  md_files <- list.files(vignettes_tempdir, pattern = '\\.md$', full.names = TRUE, ignore.case = TRUE)
+  file.rename(md_files, sub('\\.md$', '.Rmd', md_files))
+
+  tempnames <- list.files(vignette_tempdir, full.names = TRUE)
+
   file.copy(
-    list.files(vignette_tempdir, full.names = TRUE),
+    tempnames,
     vignettes_dir,
     recursive = TRUE
   )
 
-  md_files <- list.files(vignettes_dir, pattern = '\\.md$', full.names = TRUE)
-  file.rename(md_files, sub('\\.md$', '.Rmd', md_files))
+  vigs <- file.path(vignettes_dir, basename(tempnames))
 
-  rmds <- list.files(vignettes_dir, pattern = '\\.Rmd$', full.names = TRUE)
-  for(vig in rmds){
+  for(vig in vigs[!file.info(vigs)$isdir]){
     lins <- readLines(vig)
     vignette_yml <- "%%\\VignetteIndexEntry{%s}\n%%\\VignetteEngine{knitr::rmarkdown}\n%%\\VignetteEncoding{UTF-8}\n"
 

--- a/R/build.R
+++ b/R/build.R
@@ -59,11 +59,7 @@ process_vignettes <- function(path, processing_dir, vignettes_tempdir){
     vignette_yml <- "%%\\VignetteIndexEntry{%s}\n%%\\VignetteEngine{knitr::rmarkdown}\n%%\\VignetteEncoding{UTF-8}\n"
 
     if (tolower(basename(vig)) %in% tolower(basename(srcs))) { # to check if the vignette was originally an rmd file and that it has a yaml header
-      src <- readLines(srcs[ tolower(basename(srcs)) %in% tolower(basename(vig)) ])
-
-      yml_idx <- which(grepl("^---$", src))
-      if(length(yml_idx) != 2)  yml_idx <- c(0, 0)
-      rmd_yml <- yaml::read_yaml(text = src[yml_idx[1]:yml_idx[2]])
+      rmd_yml <- rmarkdown::yaml_front_matter( srcs[ tolower(basename(srcs)) %in% tolower(basename(vig)) ] )
 
       rmd_yml$vignette <-
         sprintf(

--- a/R/build.R
+++ b/R/build.R
@@ -32,17 +32,17 @@ dpr_purge_data_directory <- function(path="."){
 #'
 #' @param path the data package path to save the processed vignettes to.
 #' @param processing_dir the location processing scripts are in.
-#' @param vignette_tempdir the temp location vignettes were saved to.
+#' @param vignettes_tempdir the temp location vignettes were saved to.
 #' @return No return value. Modifies vignette files as a side effect.
 #' @noRd
-process_vignettes <- function(path, processing_dir, vignette_tempdir){
+process_vignettes <- function(path, processing_dir, vignettes_tempdir){
   vignettes_dir <- file.path(path, 'vignettes')
   if (!dir.exists(vignettes_dir)) dir.create(vignettes_dir)
 
   md_files <- list.files(vignettes_tempdir, pattern = '\\.md$', full.names = TRUE, ignore.case = TRUE)
   file.rename(md_files, sub('\\.md$', '.Rmd', md_files))
 
-  tempnames <- list.files(vignette_tempdir, full.names = TRUE)
+  tempnames <- list.files(vignettes_tempdir, full.names = TRUE)
 
   file.copy(
     tempnames,

--- a/tests/testthat/test-build.R
+++ b/tests/testthat/test-build.R
@@ -143,6 +143,21 @@ testthat::test_that("checking package build", {
     "Invalid yaml values.+render_env_mode: isolate"
   )
 
+
+  ## check that only scripts added have vignettes that are overwritten
+  scripts <- c("01.R", "01.Rmd", "02.R", "A1.R")
+  dpr_add_scripts(scripts, path)
+  dpr_build(path)
+  all_vignettes <- list.files(file.path(path, "vignettes"), full.names = T)
+  before <- file.info(all_vignettes)
+
+  dpr_rm_scripts(scripts[c(1,3)], path)
+  dpr_build(path)
+  after <- file.info(all_vignettes)
+
+  expect_true(any(before$ctime == after$ctime))
+  expect_false(all(before$ctime == after$ctime))
+
   unlink(path, recursive = TRUE)
 
   ## check that when nothing is set to process_on_build, error is as expected

--- a/tests/testthat/test-build.R
+++ b/tests/testthat/test-build.R
@@ -149,14 +149,14 @@ testthat::test_that("checking package build", {
   dpr_add_scripts(scripts, path)
   dpr_build(path)
   all_vignettes <- list.files(file.path(path, "vignettes"), full.names = T)
-  before <- file.info(all_vignettes)
+  before <- file.mtime(all_vignettes)
 
   dpr_rm_scripts(scripts[c(1,3)], path)
   dpr_build(path)
-  after <- file.info(all_vignettes)
+  after <- file.mtime(all_vignettes)
 
-  expect_true(any(before$ctime == after$ctime))
-  expect_false(all(before$ctime == after$ctime))
+  expect_true(any(before == after))
+  expect_false(all(before == after))
 
   unlink(path, recursive = TRUE)
 


### PR DESCRIPTION
This addresses #130, the issue is solved in the first commit, and other commits here address non-related house keeping and readability. A test was added in the final commit which demonstrates the expected behavior, that when scripts are removed from `to_build`, the original rendered vignettes do not change.